### PR TITLE
Change reputation signal to critical_error for checks

### DIFF
--- a/pocket-health-checks.yaml
+++ b/pocket-health-checks.yaml
@@ -8,7 +8,6 @@
 # Template format: gateway/health_check_config.go
 #
 # CHANGELOG:
-# - Added tron checks for more paths and also jsonrpc
 # - Added archival checks for all EVM chains aligned with E2E config (services_shannon.yaml)
 #   Chains with archival checks: eth, poly, bsc, avax, bera, sonic, ink, moonbeam, gnosis,
 #   celo, fantom, oasys, kaia, xrplevm, arb-one, op, base, scroll, linea, blast, boba,
@@ -49,7 +48,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -97,7 +96,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -143,7 +142,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -191,7 +190,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -231,7 +230,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -256,7 +255,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -295,7 +294,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -334,7 +333,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -373,7 +372,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -411,7 +410,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -436,7 +435,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -474,7 +473,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -512,7 +511,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -550,7 +549,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -575,7 +574,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -600,7 +599,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -625,7 +624,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -663,7 +662,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -701,7 +700,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -741,7 +740,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -816,7 +815,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -862,7 +861,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -908,7 +907,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -933,7 +932,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -958,7 +957,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -983,7 +982,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1021,7 +1020,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1060,7 +1059,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1085,7 +1084,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1123,7 +1122,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1161,7 +1160,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1199,7 +1198,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1237,7 +1236,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1262,7 +1261,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1300,7 +1299,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1329,7 +1328,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1355,7 +1354,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1380,7 +1379,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1405,7 +1404,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1430,7 +1429,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1455,7 +1454,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1480,7 +1479,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1505,7 +1504,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: eth_chainId
       type: json_rpc
@@ -1522,7 +1521,7 @@
 
 - service_id: solana
   # Block time: ~0.4s | Source: chainspect.app, solscan.io
-  # Formula: 300s / 0.4s = 750 blocks for 5 minutes
+  # Formula: 300s / 0.4s = 750 blocks for 5 minutes #updated to 1500
   sync_allowance: 1500
   check_interval: 10s
   enabled: true
@@ -1560,7 +1559,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: block
       type: json_rpc
@@ -1585,7 +1584,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"sui_getLatestCheckpointSequenceNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     - name: sui_getTotalTransactionBlocks
       type: json_rpc
@@ -1611,7 +1610,7 @@
       body: '{}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
     
     # Node list check - verifies the node has peers and is connected to the network
@@ -1642,7 +1641,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: minor_error
+      reputation_signal: critical_error
       sync_check: true
 
 # ==========================================
@@ -1671,7 +1670,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1703,7 +1702,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1735,7 +1734,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1767,7 +1766,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1799,7 +1798,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1831,7 +1830,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1863,7 +1862,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1895,7 +1894,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1927,7 +1926,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1959,7 +1958,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -1991,7 +1990,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -2023,7 +2022,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -2055,7 +2054,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -2087,7 +2086,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest
@@ -2119,7 +2118,7 @@
       body: '{"jsonrpc":"2.0","id":1,"method":"status"}'
       expected_status_code: 200
       timeout: 5s
-      reputation_signal: major_error
+      reputation_signal: critical_error
       sync_check: true
     - name: syncing
       type: rest


### PR DESCRIPTION
Updated reputation signals from 'minor_error' to 'critical_error' for multiple health checks.