### PR TITLE
Reduce sync allowance for eth service to 2

### DIFF
--- a/pocket-health-checks.yaml
+++ b/pocket-health-checks.yaml
@@ -37,7 +37,7 @@
 - service_id: eth
   # Block time: ~12s | Source: chainspect.app, etherscan.io
   # Formula: 300s / 12s = 25 blocks for 5 minutes
-  sync_allowance: 25
+  sync_allowance: 2
   check_interval: 10s
   enabled: true
   checks:


### PR DESCRIPTION
blocktime on eth is 12 sec, and that is an eternity on a computer.. clients that use eth in production environment expect to always be on the tip with this chain within a few sec.. (2 in sync allowance is 24 seconds, which is a long time on this chain, that is easy to run)